### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 .github/workflows/compliance-oss.yaml @ShopRunner/compliance
 
-* @ShopRunner/engineering
+* @ShopRunner/data-science


### PR DESCRIPTION
## Describe the big picture - why are we doing this?

The current setup pings all of engineering when someone makes a PR. I wanted to do all of engineering rather than just DS because our branch protection requires a codeowner to approve a PR before merging into `main`, and I would be OK with someone outside DS approving. However, I don't really expect anyone outside DS to review PRs into this repo, and pinging all of engineering on PRs seems excessive, so I think we should just make data-science the owner instead of engineering.

Don't worry about the failing tests -- we are working on those issues in #32 .

## Any additional details to clarify code in the PR?

## How is this tested?

## Pull Request Checklist
 - [ ] Pull request includes a description of why we are doing this
 - [ ] ``CHANGELOG`` has been updated
 - [ ] Version in ``_version.py`` has been updated
 - [ ] All tests in the ``tests`` folder pass with a local build
 - [ ] ``README`` has been updated (if applicable)
 - [ ] Documentation in ``docs`` has been updated (if applicable)
 - [ ] ``requirements.txt`` and ``requirements-dev.txt`` have been recompiled (if applicable)
 - [ ] Docker image can be built using ``docker build -t collie .``

## Screenshots or GIFs?
